### PR TITLE
fix(feedback): remove hardcoded client review link default

### DIFF
--- a/frontend/src/pages/Feedback.jsx
+++ b/frontend/src/pages/Feedback.jsx
@@ -30,7 +30,7 @@ export default function Feedback() {
     channel: 'whatsapp',
     askReview: true,
     reviewThreshold: 4,
-    reviewLink: 'https://g.page/ellindigo/review',
+    reviewLink: '',
   });
   const [settingsDirty, setSettingsDirty] = useState(false);
 


### PR DESCRIPTION
## Summary

- Removes the hardcoded `https://g.page/ellindigo/review` default value from the `reviewLink` setting in `Feedback.jsx`
- The default is now an empty string, so new salons are not silently pre-populated with a specific client's Google review URL

## Why

Every new signup would have "Ellie's" review link pre-filled. Any salon that saved Feedback settings without noticing the field would end up directing their happy clients to the wrong business's Google reviews page.

## Test plan

- [ ] Open `/feedback` as a brand-new salon account — verify the Google Review Link field is empty
- [ ] Open `/feedback` as an existing salon that already has a saved `reviewLink` — verify their saved value is still shown (state comes from Supabase, not this default)

Closes #21

https://claude.ai/code/session_01SMFkGV6Ci2L9tCpxnG8yFw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMFkGV6Ci2L9tCpxnG8yFw)_