### PR TITLE
fix: stale Claude model ID + seed review link in default state

### DIFF
--- a/backend/src/routes/webhooks.js
+++ b/backend/src/routes/webhooks.js
@@ -631,7 +631,7 @@ async function transcribeWhatsAppAudio(mediaId, mimeType) {
   // Step 3: Transcribe using Claude (supports audio input)
   const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
   const response = await anthropic.messages.create({
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     max_tokens: 1000,
     messages: [{
       role: 'user',

--- a/frontend/src/pages/Feedback.jsx
+++ b/frontend/src/pages/Feedback.jsx
@@ -30,7 +30,7 @@ export default function Feedback() {
     channel: 'whatsapp',
     askReview: true,
     reviewThreshold: 4,
-    reviewLink: 'https://g.page/ellindigo/review',
+    reviewLink: '',
   });
   const [settingsDirty, setSettingsDirty] = useState(false);
 


### PR DESCRIPTION
## Summary

Two quick-win fixes surfaced during weekly code review (issue #30):

- **`backend/src/routes/webhooks.js:634`** — `claude-sonnet-4-20250514` is a non-existent model alias that would throw a `model_not_found` error on every WhatsApp voice message. Updated to `claude-sonnet-4-6` (consistent with the rest of the codebase).
- **`frontend/src/pages/Feedback.jsx:33`** — Ellie seed user's Google review URL (`https://g.page/ellindigo/review`) was the hardcoded default initial state for ALL users. Any user who saved before settings fetched from the DB would have stored Ellie's URL as their own. Default is now `''`.

## Test plan

- [ ] Send a WhatsApp voice message to the AI front desk — confirm transcription succeeds (no `model_not_found` error in Railway logs)
- [ ] Open Feedback page as a new user with no saved settings — confirm review link input is blank, not prefilled with a third-party URL
- [ ] Open Feedback page as an existing user with a saved review link — confirm their link still loads correctly

Closes two findings from #30.

https://claude.ai/code/session_013342FTE6vyqYn2bxpfA36t

---
_Generated by [Claude Code](https://claude.ai/code/session_013342FTE6vyqYn2bxpfA36t)_