### PR TITLE
fix(frontend): replace SheetJS CDN URL — restores npm install & build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.0.0",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
+    "xlsx": "0.18.5"
   },
   "devDependencies": {
     "@capacitor/cli": "^6.0.0",


### PR DESCRIPTION
## Problem

`npm install` in `frontend/` fails with HTTP 403 on the SheetJS CDN:

```
npm error 403 Forbidden - GET https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
```

Because the install never completes, `vite` is never available and the build fails:

```
sh: 1: vite: not found
```

This was caught by the nightly health check on 2026-06-06.

## Fix

Replace the CDN-pinned URL with the npm-registry version `0.18.5` — the last freely published SheetJS release.

```diff
- "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
+ "xlsx": "0.18.5"
```

## Compatibility

All three xlsx APIs used in `frontend/src/pages/ClientImport.jsx` are present in 0.18.5:

| API | Available in 0.18.5 |
|---|---|
| `XLSX.read(buf, { type: 'array' })` | ✅ |
| `XLSX.utils.decode_range()` | ✅ |
| `XLSX.utils.sheet_to_csv()` | ✅ |

## Note on SheetJS licensing

SheetJS moved to a commercial model in newer versions and removed packages from npm. If a 0.20.x feature is needed, a paid Pro licence is required to authenticate against their CDN. For now, 0.18.5 covers all current usage.

https://claude.ai/code/session_019rkAwUinZEak8rpUDam6os

---
_Generated by [Claude Code](https://claude.ai/code/session_019rkAwUinZEak8rpUDam6os)_