### PR TITLE
fix(stripe): remove duplicate error log lines in 5 catch blocks

### DIFF
--- a/backend/src/routes/stripe.js
+++ b/backend/src/routes/stripe.js
@@ -227,7 +227,6 @@ router.post('/checkout', requireAuth, requireStripe, async (req, res) => {
     res.json({ url: session.url, session_id: session.id });
   } catch (err) {
     logger.error({ err }, 'Checkout session error');
-    logger.error({ err }, 'Stripe operation failed');
     res.status(500).json({ error: 'Something went wrong' });
   }
 });
@@ -284,7 +283,6 @@ router.post('/subscribe', requireAuth, requireStripe, async (req, res) => {
     res.json({ url: session.url });
   } catch (err) {
     logger.error({ err }, 'Subscribe error');
-    logger.error({ err }, 'Stripe operation failed');
     res.status(500).json({ error: 'Something went wrong' });
   }
 });
@@ -552,7 +550,6 @@ router.post('/refund', requireAuth, requireStripe, async (req, res) => {
     });
   } catch (err) {
     logger.error({ err }, 'Refund error');
-    logger.error({ err }, 'Stripe operation failed');
     res.status(500).json({ error: 'Something went wrong' });
   }
 });
@@ -660,7 +657,6 @@ router.post('/payment-link', requireAuth, requireStripe, async (req, res) => {
     });
   } catch (err) {
     logger.error({ err }, 'Payment link error');
-    logger.error({ err }, 'Stripe operation failed');
     res.status(500).json({ error: 'Something went wrong' });
   }
 });
@@ -686,7 +682,6 @@ router.post('/cleanup-events', async (req, res) => {
     res.json({ success: true, ...result });
   } catch (err) {
     logger.error({ err }, 'Stripe cleanup error');
-    logger.error({ err }, 'Stripe operation failed');
     res.status(500).json({ error: 'Something went wrong' });
   }
 });


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Each of 5 catch blocks in `backend/src/routes/stripe.js` was calling `logger.error` twice — once with a specific context label and again with the generic `'Stripe operation failed'`
- Removed the redundant second call in each block; the specific label is more useful anyway
- No logic change, no behaviour change — purely a log hygiene fix

## Files changed

- `backend/src/routes/stripe.js` — lines 228–230, 285–287, 553–555, 661–663, 687–689

## Test plan

- [ ] Deploy to staging and trigger a Stripe error (e.g. invalid plan_id) — confirm log stream shows exactly **one** error entry per failure, not two

> Opened as part of the weekly automated code review.

https://claude.ai/code/session_01YW1dyeb1RtziWcRGJpyZUV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YW1dyeb1RtziWcRGJpyZUV)_