### PR TITLE
fix(data-leak): remove pilot user slug hardcoded in Feedback default and Aftercare preview

### DIFF
--- a/frontend/src/pages/Aftercare.jsx
+++ b/frontend/src/pages/Aftercare.jsx
@@ -567,7 +567,7 @@ export default function Aftercare() {
 
                   {settings.include_rebook_link && (
                     <div style={styles.phoneRebook}>
-                      📅 Ready to rebook? → florrie.ai/book/ellindigo
+                      📅 Ready to rebook? → florrie.ai/book/{beautician?.booking_slug || 'your-link'}
                     </div>
                   )}
                 </div>

--- a/frontend/src/pages/Feedback.jsx
+++ b/frontend/src/pages/Feedback.jsx
@@ -30,7 +30,7 @@ export default function Feedback() {
     channel: 'whatsapp',
     askReview: true,
     reviewThreshold: 4,
-    reviewLink: 'https://g.page/ellindigo/review',
+    reviewLink: '',
   });
   const [settingsDirty, setSettingsDirty] = useState(false);
 


### PR DESCRIPTION
## What

Removes two occurrences of the pilot user's booking slug (`ellindigo`) that were baked into production code.

### `frontend/src/pages/Feedback.jsx:33`

The `reviewLink` initial state was `'https://g.page/ellindigo/review'`. Any new salon whose Feedback settings had never been explicitly saved would have their 5-star reviews directed to the pilot user's Google business page. Changed to `''` (empty string) — the UI already shows a placeholder in the input field when the value is blank.

### `frontend/src/pages/Aftercare.jsx:570`

The aftercare card preview hardcoded `florrie.ai/book/ellindigo` as the rebook link regardless of which salon was logged in. Changed to `florrie.ai/book/{beautician?.booking_slug || 'your-link'}` so the preview reflects the signed-in salon.

## Why now

A previous commit (`718750f`) already redacted a pilot user's personal phone number. This sweeps two more instances of the same class of issue caught in the weekly automated code review.

## Test plan

- [ ] Sign in as a **new** salon (no saved Feedback settings) → Feedback page → confirm review link input is empty, not `g.page/ellindigo/review`
- [ ] Aftercare page → Cards tab → open any card preview → confirm rebook link shows the signed-in salon's slug (or `your-link` if slug not set)
- [ ] Existing salon with a saved review link → confirm it still loads from the database, not overridden by the empty default

https://claude.ai/code/session_01SPFQgngLWm6UuzJV3JYJiN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPFQgngLWm6UuzJV3JYJiN)_