### PR TITLE
fix(emails): correct trial-warning price £19 → £29/month

### DIFF
--- a/backend/src/services/email-sequences.js
+++ b/backend/src/services/email-sequences.js
@@ -412,13 +412,13 @@ function trialWarning(b) {
       But the AI features will pause until you pick a plan.
     </p>
     <p style="margin:0 0 16px;color:#6b6560;font-size:15px;line-height:1.6">
-      Plans start at £19/month. That's less than one brow appointment —
+      Plans start at £29/month. That's less than one brow appointment —
       and it saves you 8+ hours a week.
     </p>
     ${ctaButton('Choose a plan', 'https://florrie.ai/settings#billing', b.brand_color || '#92405E')}
   `);
 
-  const text = `Hey ${name}, your Florrie trial ends in 3 days. Your data is safe — but AI features will pause. Plans start at £19/month. Choose a plan: https://florrie.ai/settings#billing`;
+  const text = `Hey ${name}, your Florrie trial ends in 3 days. Your data is safe — but AI features will pause. Plans start at £29/month. Choose a plan: https://florrie.ai/settings#billing`;
 
   return { html, text };
 }


### PR DESCRIPTION
## What

The trial-ending email (sent 3 days before expiry) stated "Plans start at £19/month" in both its HTML and plain-text variants. The actual price is **£29/month** as defined in `frontend/src/lib/subscription.js` and `frontend/src/components/CheckoutModal.jsx`.

## Why it matters

Every user who received this email before upgrading was shown a price £10 cheaper than they actually paid — a credibility and trust issue the moment they hit the checkout screen.

## Change

`backend/src/services/email-sequences.js` — two-line fix in `trialWarning()`:
- HTML body: `£19/month` → `£29/month`
- Plain-text fallback: same

## Test

No logic change; the strings are verified against `subscription.js` pricing constants.

---
Found during weekly automated code review — 2026-06-16 → 2026-06-22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVvL15EE4c4q1miLF95NxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVvL15EE4c4q1miLF95NxJ)_