### PR TITLE
fix: correct trial-ending email price from £19 to £29/month

### DIFF
--- a/backend/src/services/email-sequences.js
+++ b/backend/src/services/email-sequences.js
@@ -412,13 +412,13 @@ function trialWarning(b) {
       But the AI features will pause until you pick a plan.
     </p>
     <p style="margin:0 0 16px;color:#6b6560;font-size:15px;line-height:1.6">
-      Plans start at £19/month. That's less than one brow appointment —
+      Plans start at £29/month. That's less than one brow appointment —
       and it saves you 8+ hours a week.
     </p>
     ${ctaButton('Choose a plan', 'https://florrie.ai/settings#billing', b.brand_color || '#92405E')}
   `);
 
-  const text = `Hey ${name}, your Florrie trial ends in 3 days. Your data is safe — but AI features will pause. Plans start at £19/month. Choose a plan: https://florrie.ai/settings#billing`;
+  const text = `Hey ${name}, your Florrie trial ends in 3 days. Your data is safe — but AI features will pause. Plans start at £29/month. Choose a plan: https://florrie.ai/settings#billing`;
 
   return { html, text };
 }


### PR DESCRIPTION
## Summary

- Trial-expiry email sequence (`email-sequences.js`) was quoting **£19/month** in two places (HTML body and plain-text fallback)
- The canonical price defined in `tiers.js` is **£29/month**
- Customers receiving this email would see a different price to the one shown at Stripe checkout, undermining trust

## Changes

- `backend/src/services/email-sequences.js:415` — HTML copy: £19 → £29
- `backend/src/services/email-sequences.js:421` — Plain-text copy: £19 → £29

No logic changes, copy-only fix. Caught by the weekly automated code review.

---
_Generated by [Claude Code](https://claude.ai/code/session_014C2rcwsw86QhjXyPqjhkK9)_